### PR TITLE
[DEVO-269]fix deprecated commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,22 +36,22 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
-    compile group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'
-    compile 'org.apache.commons:commons-text:1.6'
-    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
-    compile 'com.google.code.gson:gson:2.8.5'
-    compile 'com.google.guava:guava:27.0.1-jre'
-    compile group: 'com.ibm.informix', name: 'jdbc', version: '4.10.12'
-    compile group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '7.0.0.jre8'
-    compile group: 'com.amazon.redshift', name: 'redshift-jdbc42', version: '1.2.10.1009'
-    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.9-rc'
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.1'
-    compile group: 'net.snowflake', name: 'snowflake-jdbc', version: '3.6.25'
-    compile group: 'com.syncron.amazonaws', name: 'simba-athena-jdbc-driver', version: '2.0.2'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    implementation group: 'commons-cli', name: 'commons-cli', version: '1.4'
+    implementation group: 'commons-dbutils', name: 'commons-dbutils', version: '1.7'
+    implementation 'org.apache.commons:commons-text:1.6'
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.guava:guava:27.0.1-jre'
+    implementation group: 'com.ibm.informix', name: 'jdbc', version: '4.10.12'
+    implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '7.0.0.jre8'
+    implementation group: 'com.amazon.redshift', name: 'redshift-jdbc42', version: '1.2.10.1009'
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.9-rc'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.1'
+    implementation group: 'net.snowflake', name: 'snowflake-jdbc', version: '3.6.25'
+    implementation group: 'com.syncron.amazonaws', name: 'simba-athena-jdbc-driver', version: '2.0.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 buildscript {


### PR DESCRIPTION
Gradle has [finally removed](https://docs.gradle.org/7.0/release-notes.html) some deprecated features (v4.0) within latest build of Gradle 7. This was released on April 9th, 2021 when our builds started failing.

`compile` - is now - `implementation`
`testCompile` - is now - `testImplementation`

I've validated locally via `gradle shadowJar`.