### PR TITLE
[DEVO-746]sql update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ gradle shadowJar
 
 ### Publish
 
-First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/simon/sql-extractor)
+First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/sql-extractor)
 ```sh
 gradle clean shadowJar artifactoryPublish
 ```

--- a/README.md
+++ b/README.md
@@ -35,22 +35,17 @@ Build 'uberjar' to run as a standalone app.
 gradle shadowJar
 ```
 
-Generate sources jar to `/build/libs` 
-```$sh
-gradle sources
-```
-
-Generate javadoc to `build/docs`
-```$sh
-gradle javadoc
-```
-
 ### Publish
 
-Publish a new release to JFrog Artifactory
+First publish a new release to [JFrog Artifactory](https://simondata.jfrog.io/ui/repos/tree/General/gradle-virtual/gradle-int/simon/sql-extractor)
 ```sh
-gradle artifactoryPublish
+gradle clean shadowJar artifactoryPublish
 ```
+
+You will see a version pushed like `sql-extractor-0.0.x-all.jar` in the output of the publish.
+
+Next, update Jenkins build argument for the version to pull into the container.
+[Jenkins Build Base Container](https://misc.automation.simondata.net/job/build-base-web-container/configure)
 
 ## Usage
 ### Use as a library

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-group 'simon'
-
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
 apply plugin: 'signing'
 apply plugin: 'application'
-apply plugin: 'net.researchgate.release'
-apply plugin: 'org.ajoberstar.git-publish'
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 apply plugin: "com.jfrog.artifactory"
@@ -115,42 +111,18 @@ allprojects {
     apply plugin: "com.jfrog.artifactory"
 }
 
-release {
-    preTagCommitMessage = '[Gradle Release Plugin] - pre tag commit: '
-    tagCommitMessage = '[Gradle Release Plugin] - creating tag: '
-    newVersionCommitMessage = '[Gradle Release Plugin] - new version commit: '
-    tagTemplate = '${version}'
-    versionPropertyFile = 'gradle.properties'
-    buildTasks = ['build', 'shadowJar']
-    scmAdapters = [net.researchgate.release.GitAdapter]
-    git {
-        requireBranch = 'master'
-        pushToRemote = 'origin'
-        pushToBranchPrefix = ''
-        commitVersionFileOnly = false
-        signTag = false
-    }
-}
-
-
-task sourcesJar(type: Jar) {
+task sourceJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allJava
     archiveClassifier = 'sources'
 }
 
-task javadocJar(type: Jar) {
-    from javadoc
-    archiveClassifier = 'javadoc'
-}
-
-
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        shadow(MavenPublication) { publication ->
+            from project.shadow.component(publication)
             artifactId = 'sql-extractor'
-            from components.java
-            artifact sourcesJar
-            artifact javadocJar
+            artifact sourceJar
+            artifact shadowJar
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')
@@ -195,27 +167,9 @@ publishing {
 }
 
 signing {
-    sign publishing.publications.mavenJava
-}
-
-
-javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}
-
-gitPublish {
-    repoUri = 'git@github.com:Radico/sql-extractor.git'
-    referenceRepoUri = System.getProperty("user.dir")
-    branch = 'gh-pages'
-    repoDir = file("$buildDir/git-publish") // defaults to $buildDir/gitPublish
-
-    contents {
-        from 'src/pages'
-        from(javadoc) {
-            into 'api'
-        }
+    setRequired {
+        // signing is only required if the artifacts are to be published
+        gradle.taskGraph.allTasks.any { it.equals( PublishToMavenRepository) }
     }
 }
 
@@ -230,9 +184,11 @@ artifactory {
 
         }
         defaults {
-            //publications ('ivyJava','mavenJava')
+            publications ('shadow')
             //List of Gradle Configurations (names or objects) from which to collect the list of artifacts to be deployed to Artifactory.
-            publishConfigs('archives', 'published')
+            publishBuildInfo = false
+            publishPom = false
+            publishIvy = false
         }
     }
     resolve {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.0.4-SNAPSHOT
+version=0.0.5
 artifactory_contextUrl=https://simondata.jfrog.io/artifactory/gradle-virtual


### PR DESCRIPTION
* Update README with build/publish information and link to JFrog
* Clean up gradle script for publishing
    * Gradle `mavenJava` publication is the standard thin jar, not the shadow "fat" jar. This was getting picked up in the original publishing directives and overlooked when Artifactory plugin was added. Fix this to use the `shadow` jar
    * Remove broken javadocs - not enough comments to publish docs
    * Remove unused git publish and release plugins
    * Remove `group` which doesn't match the repository group in the pom that is published to Artifactory
    * Bump version